### PR TITLE
Add per project listener mode

### DIFF
--- a/src/test/kotlin/io/kotest/extensions/wiremock/ProjectConfig.kt
+++ b/src/test/kotlin/io/kotest/extensions/wiremock/ProjectConfig.kt
@@ -1,0 +1,18 @@
+package io.kotest.extensions.wiremock
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.github.tomakehurst.wiremock.client.WireMock
+import io.kotest.core.config.AbstractProjectConfig
+
+object ProjectConfig : AbstractProjectConfig() {
+    const val WIREMOCK_SERVER_PORT = 9001
+
+    val wiremock = WireMockServer(WIREMOCK_SERVER_PORT)
+    val wiremockListener = WireMockListener(wiremock, ListenerMode.PER_PROJECT)
+
+    override fun extensions() = listOf(wiremockListener)
+
+   override suspend fun beforeProject() {
+      WireMock.configureFor(WIREMOCK_SERVER_PORT)
+   }
+}

--- a/src/test/kotlin/io/kotest/extensions/wiremock/WiremockListenerPerProjectTest.kt
+++ b/src/test/kotlin/io/kotest/extensions/wiremock/WiremockListenerPerProjectTest.kt
@@ -1,0 +1,31 @@
+package io.kotest.extensions.wiremock
+
+import com.github.tomakehurst.wiremock.client.WireMock.get
+import com.github.tomakehurst.wiremock.client.WireMock.ok
+import com.github.tomakehurst.wiremock.client.WireMock.stubFor
+import com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo
+import io.kotest.core.spec.style.FunSpec
+import io.kotest.matchers.shouldBe
+import java.net.HttpURLConnection
+import java.net.URL
+
+@Suppress("BlockingMethodInNonBlockingContext")
+class WiremockListenerPerProjectTest : FunSpec({
+   test("should have started wiremock server") {
+      stubFor(
+         get(urlEqualTo("/test"))
+            .willReturn(ok())
+      )
+      val connection = URL("http://localhost:9001/test").openConnection() as HttpURLConnection
+      connection.responseCode shouldBe 200
+   }
+
+   test("should have started wiremock server for second test as well") {
+      stubFor(
+         get(urlEqualTo("/second-test"))
+            .willReturn(ok())
+      )
+      val connection = URL("http://localhost:9001/second-test").openConnection() as HttpURLConnection
+      connection.responseCode shouldBe 200
+   }
+})


### PR DESCRIPTION
It allows to share `WireMock` instance in all tests.