### PR TITLE
Upgrade Wiremock to version 3

### DIFF
--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -17,7 +17,7 @@ jobs:
          -  name: Setup JDK
             uses: actions/setup-java@v3
             with:
-               java-version: '8'
+               java-version: '11'
                distribution: 'zulu'
 
          -  name: Run tests

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -20,7 +20,7 @@ jobs:
          -  name: Setup JDK
             uses: actions/setup-java@v3
             with:
-               java-version: '8'
+               java-version: '11'
                distribution: 'zulu'
 
          -  name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,7 @@ jobs:
          -  name: Setup JDK
             uses: actions/setup-java@v3
             with:
-               java-version: '8'
+               java-version: '11'
                distribution: 'zulu'
 
          -  name: deploy to sonatype

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ plugins {
    `java-library`
    signing
    `maven-publish`
-   kotlin("jvm") version "1.6.21"
+   kotlin("jvm") version "1.9.21"
 }
 
 group = "io.kotest.extensions"
@@ -35,7 +35,7 @@ tasks.test {
 }
 
 tasks.withType<KotlinCompile> {
-   kotlinOptions.jvmTarget = "1.8"
+   kotlinOptions.jvmTarget = "11"
 }
 
 val signingKey: String? by project
@@ -57,6 +57,9 @@ signing {
 java {
    withJavadocJar()
    withSourcesJar()
+   toolchain {
+      languageVersion.set(JavaLanguageVersion.of(11))
+   }
 }
 
 publishing {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-wiremock = "2.35.1"
+wiremock = "3.3.1"
 kotest = "5.5.4"
 
 [libraries]
@@ -7,4 +7,4 @@ kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref =
 kotest-api = { module = "io.kotest:kotest-framework-api", version.ref = "kotest" }
 kotest-runner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 
-wiremock = { module = "com.github.tomakehurst:wiremock-jre8-standalone", version.ref = "wiremock" }
+wiremock = { module = "org.wiremock:wiremock", version.ref = "wiremock" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.3-all.zip
 networkTimeout=10000
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
This PR upgrades Wiremock to version 3.3.1. 

The upgrade can't be performed by Renovate, because the coordinates have changed from

    com.github.tomakehurst:wiremock-jre8-standalone

to

    org.wiremock:wiremock

Funny enough, the package names stay the same.