### PR TITLE
Switch back to WireMock standalone version

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,4 +7,4 @@ kotest-assertions = { module = "io.kotest:kotest-assertions-core", version.ref =
 kotest-api = { module = "io.kotest:kotest-framework-api", version.ref = "kotest" }
 kotest-runner = { module = "io.kotest:kotest-runner-junit5", version.ref = "kotest" }
 
-wiremock = { module = "org.wiremock:wiremock", version.ref = "wiremock" }
+wiremock = { module = "org.wiremock:wiremock-standalone", version.ref = "wiremock" }


### PR DESCRIPTION
No other changes besides switching back to WireMock standalone packaging version.

Fixes https://github.com/kotest/kotest-extensions-wiremock/issues/39.

